### PR TITLE
Skip passing default arguments when adding named arguments

### DIFF
--- a/tests/DefaultStrategy/Fixture/construct.php.inc
+++ b/tests/DefaultStrategy/Fixture/construct.php.inc
@@ -6,6 +6,6 @@ new DateTimeImmutable('now');
 -----
 <?php
 
-new DateTimeImmutable(datetime: 'now');
+new DateTimeImmutable();
 
 ?>

--- a/tests/DefaultStrategy/Fixture/remove_default_args.php.inc
+++ b/tests/DefaultStrategy/Fixture/remove_default_args.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+preg_split('/,/', 'a,b', -1, PREG_SPLIT_NO_EMPTY);
+?>
+-----
+<?php
+
+preg_split(pattern: '/,/', subject: 'a,b', flags: PREG_SPLIT_NO_EMPTY);
+?>


### PR DESCRIPTION
## Summary
- omit arguments that match parameter defaults when converting to named arguments
- test skipping of default arguments in function calls

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b82ee7e4d08324b798a65ec4677979