### PR TITLE
Add missing webmozart/assert runtime dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
         "nikic/php-parser": "^4.19.4 || ^5.1",
+        "php": ">=8.2",
         "phpstan/phpstan": "^2.1.5",
         "rector/rector": "^2.0.9",
-        "symplify/rule-doc-generator-contracts": "^11.2"
+        "symplify/rule-doc-generator-contracts": "^11.2",
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.45",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "nikic/php-parser": "^4.19.4 || ^5.1",
         "php": ">=8.2",
+        "nikic/php-parser": "^4.19.4 || ^5.1",
         "phpstan/phpstan": "^2.1.5",
         "rector/rector": "^2.0.9",
         "symplify/rule-doc-generator-contracts": "^11.2",


### PR DESCRIPTION
### Description
- Add `webmozart/assert` (version `^1.11`) to the `require` section of `composer.json` so the runtime assertion library is explicitly available.

### Testing
- Ran `composer validate --no-check-publish` which succeeded.

